### PR TITLE
Added fallback for profile pics.

### DIFF
--- a/src/components/UserCard/index.tsx
+++ b/src/components/UserCard/index.tsx
@@ -9,6 +9,12 @@ export interface UserCardProps extends PeopleSchema {
 const UserCard: React.FC<UserCardProps> = ({ onClick, ...props }) => {
   // const social = getSocialInfo(props);
 
+  // Sets alternate image from ui-avatars.com if original URL doesn't work
+  function setAlternate(e: React.SyntheticEvent, name: any){
+    let imageTag = e.currentTarget as HTMLImageElement;
+    imageTag.setAttribute("src", `https://ui-avatars.com/api/?name=${name}&size=460`);
+  };
+
   return (
     <Popup
       content={getTooltipContent(props)}
@@ -25,6 +31,7 @@ const UserCard: React.FC<UserCardProps> = ({ onClick, ...props }) => {
           onClick={() => onClick && onClick(props)}
           className="m-2"
           style={{ cursor: "pointer" }}
+          onError={(event:React.SyntheticEvent)=>setAlternate(event, props.Name)}
         />
       }
     />

--- a/src/containers/People/index.tsx
+++ b/src/containers/People/index.tsx
@@ -91,6 +91,12 @@ class People extends React.Component<PeopleProps, PeopleState> {
     );
   };
 
+  // Sets alternate image from ui-avatars.com if original URL doesn't work
+  setAlternate(e: React.SyntheticEvent, name: any){
+    let imageTag = e.currentTarget.childNodes[0] as HTMLImageElement;
+    imageTag.setAttribute("src", `https://ui-avatars.com/api/?name=${name}&size=460`);
+  };
+  
   render() {
     const peopleCat = this._getPeopleCategory(people);
     const { selectedProfile } = this.state;
@@ -146,6 +152,7 @@ class People extends React.Component<PeopleProps, PeopleState> {
                   selectedProfile?.Thumbnail ||
                   `https://ui-avatars.com/api/?name=${selectedProfile?.Name}&size=460`
                 }
+                onError={(event:React.SyntheticEvent)=>this.setAlternate(event,selectedProfile?.Name)}
               />
               <Modal.Description>
                 <Header>{selectedProfile?.Name}</Header>


### PR DESCRIPTION
### Added fallback image for profile pic in people's page as I said https://github.com/LoginRadius/cascade/issues/4#issuecomment-701412740
 
## Fixed #4.

#### Changes proposed in the pull request:
- Added onError event listener in Usercard and People components
- Added setAlternative() for auditing source when error occurs i.e. image couldn't be loaded

#### Risk Impact
- The function setAleternative() might be in inappropriate position considering your codebase, but it is fully working, and you can shift or modify it's position if necessary

Please tell me if I have done something which is not recommended or not advisable :)

@mohammed786
